### PR TITLE
fix broken download link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 cache/*
+!cache/.keep

--- a/cache/placeholder.txt
+++ b/cache/placeholder.txt
@@ -1,1 +1,0 @@
-This file has intentionally been left blank.

--- a/vars.sh
+++ b/vars.sh
@@ -8,6 +8,6 @@ metal_url=http://www.sph.umich.edu/csg/abecasis/Metal/download/Linux-metal.tar.g
 shapeit_url=https://mathgen.stats.ox.ac.uk/genetics_software/shapeit/shapeit.v2.r900.glibcv2.17.linux.tar.gz
 shapeit_name=shapeit.v2.900.glibcv2.17.linux # not same dirname as the inside tarball lol
 impute_url=https://mathgen.stats.ox.ac.uk/impute/impute_v2.3.2_x86_64_static.tgz
-plink_url=https://www.cog-genomics.org/static/bin/plink180109/plink_linux_x86_64.zip
+plink_url=https://www.cog-genomics.org/static/bin/plink/plink_linux_x86_64.zip
 eigensoft_url=https://github.com/DReichLab/EIG/archive/v7.2.1.tar.gz
 eagle_url=https://data.broadinstitute.org/alkesgroup/Eagle/downloads/Eagle_v2.4.tar.gz


### PR DESCRIPTION
Container doesn't build, bc of broken download link (plink1). 
I fixed the link. Now the link is pointing to an older version - it's less likely to change. 

However, a cleaner way to deal with this: Pull plink source from github and and build it with dockerfile. I have the code ready [1]. Let me know if you want to have it added. 

[1] https://github.com/f-krull/GRSworkflow/commit/200bf8734f194b445ffb245e9806c542826f8b68
